### PR TITLE
Add certificate expiration guard

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/sirupsen/logrus v1.6.0
+	github.com/stretchr/testify v1.6.1
 	google.golang.org/grpc v1.29.1
 	gotest.tools v2.2.0+incompatible
 )

--- a/pkg/provider/tls/cert.go
+++ b/pkg/provider/tls/cert.go
@@ -1,0 +1,37 @@
+package tls
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"time"
+)
+
+// To make things less complex / MVP, I'm assuming:
+// Certificates bytes are DER formatted in a PEM encoded file
+// Private keys are RSA formatted in a PEM encoded (PKCS#8) file.
+//
+// Maybe we can add more ways in the future, but I'm hoping this standard suffices.
+
+// validatePublicCertificate will return errors when the certificate is not properly formatted/encoded or has expired
+func validatePublicCertificate(certBytes []byte) error {
+	block, _ := pem.Decode(certBytes)
+	if block == nil {
+		return errors.New("no PEM block found")
+	}
+
+	if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+		return errors.New("PEM block is not a certificate")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return err
+	}
+
+	if cert.NotAfter.Before(time.Now()) {
+		return errors.New("certificate expired")
+	}
+
+	return nil
+}

--- a/pkg/provider/tls/cert_test.go
+++ b/pkg/provider/tls/cert_test.go
@@ -1,0 +1,69 @@
+package tls
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var malformedStructure = `-----BEGIN CERTIFICATE-----
+f01bTJgaKI4N9Xyqodw5RcatOlBkiWb80nGPsOo2ri/oP8/KbpHWwMhLzgyXDDeq
+ibtJfCb52he7l3x6KRThlGPPp1C0u7Vn8saT0/XR+fJZYsSvdzXScC2pzrTt7nzt
+R20quVGea+q83eLqxRzlFqcPCiAtoMbOkqBQQe9NqR5BTod0mXMxHLmTsGfgvk/c
+tbMN8uBGoRQsJHAoFF6PqWBA101d5+8ujGHfMsh2/zzuL7ylsRmjh//vjeuWYWSQ
+8/vzvz5EiZ3EaNhZzCVc3H43FgQq1wgVJ1v1hSpFAIekN7nAyceg3M6aOBc6/CVY
+d1DRCb/U1TUlA24y4i/Pgg==
+-----END CERTIFICATE-----
+`
+
+func TestValidatePublicCertificateMalformedStructure(t *testing.T) {
+	result := validatePublicCertificate([]byte(malformedStructure))
+
+	assert.Error(t, result)
+	assert.Contains(t, result.Error(), "asn1: structure error")
+}
+
+func TestValidatePublicCertificateNoPemEncoding(t *testing.T) {
+	result := validatePublicCertificate([]byte("randomcertificatebyteswithoutaheader"))
+
+	assert.EqualError(t, result, "no PEM block found")
+}
+
+func TestValidatePublicCertificateExpiredCertificate(t *testing.T) {
+	cert := createCertificate(time.Now().AddDate(0, 0, -1))
+
+	result := validatePublicCertificate(cert)
+
+	assert.EqualError(t, result, "certificate expired")
+}
+
+func TestValidatePublicCertificateValidCertificate(t *testing.T) {
+	cert := createCertificate(time.Now().Add(5 * time.Second))
+
+	assert.NoError(t, validatePublicCertificate(cert))
+}
+
+func createCertificate(expiry time.Time) []byte {
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test", Organization: []string{"Supercorp."}},
+		NotBefore:    time.Now(),
+		NotAfter:     expiry,
+		KeyUsage:     x509.KeyUsageCertSign,
+	}
+
+	cert, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		panic("could not generate cert for tests: " + err.Error())
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert})
+}

--- a/pkg/provider/tls/storage/file.go
+++ b/pkg/provider/tls/storage/file.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 )
 
-// We'll use .pem and .key files to store our certificates, keeping it close to the RFCs 1421 through 1424
+// We'll use .pem and .key files to store our certificate and private key, trying to play nice with x509 standards
+// Note that this storage doesn't know anything about the encoding and merely exists to write bytes to disk
 const CertificateExtension = "pem"
 const PrivateKeyExtension = "key"
-const CertificateFileMode = 0600
 
 // getCertificateFilename contains the business logic for generating consistent certificate file names
 func getCertificateFilename(primaryDomain string, sans []string) string {


### PR DESCRIPTION
TLS/SDS provider will no longer return certificates that are expired